### PR TITLE
Switch Rocket badges

### DIFF
--- a/src/pages/rockets.css
+++ b/src/pages/rockets.css
@@ -24,3 +24,30 @@
   border: none;
   padding: 1%;
 }
+
+.rocket_reserve.false {
+  background: #0290ff;
+  color: #fff;
+  font-weight: bold;
+  border: none;
+  padding: 1.5%;
+}
+
+.rocket_reserve.true {
+  background: #fff;
+  color: #888;
+  font-weight: bold;
+  border: solid 0.5px #888;
+  padding: 1%;
+}
+
+.reserve_span {
+  background: #0290ff;
+  color: #fff;
+  font-weight: bold;
+  border: none;
+  font-size: 70%;
+  border-radius: 4px;
+  padding: 0.5%;
+  margin-right: 1%;
+}

--- a/src/pages/rockets.js
+++ b/src/pages/rockets.js
@@ -12,14 +12,56 @@ const Rockets = (props) => {
       {rockets.map((rocket) => (
         <li className="rocket_item" key={rocket.id}>
           <div className="rocket_image_container">
-            <img className="rocket_images" alt={rocket.rocket_name} src={rocket.flickr_images} />
+            <img
+              className="rocket_images"
+              alt={rocket.rocket_name}
+              src={rocket.flickr_images}
+            />
           </div>
           <div className="rocket_paragraph_container">
             <h3>{rocket.rocket_name}</h3>
-            <p>{rocket.description}</p>
+            {rocket.reserved === true && (
+              <span className="reserve_span">
+                Reserved
+                {' '}
+              </span>
+            )}
+            <span>{rocket.description}</span>
             <p>{`Type: ${rocket.rocket_type}`}</p>
-            <button onClick={() => reserveRocketsProps(rocket.id)} className="rocket_reserve" type="button">Reserve Rocket</button>
+            <button
+              onClick={() => reserveRocketsProps(rocket.id)}
+              className={`rocket_reserve ${rocket.reserved}`}
+              type="button"
+            >
+              {rocket.reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
+            </button>
           </div>
+          {/* {!rocket.reserved && (
+              <button
+                onClick={() => reserveRocketsProps(rocket.id)}
+                className="rocket_reserve"
+                type="button"
+              >
+                Reserve Rocket
+              </button>
+            )}
+            {rocket.reserved === true && (
+              <button
+                type="button"
+                onClick={() => reserveRocketsProps(rocket.id)}
+              >
+                Cancel Reservation
+              </button>
+            )}
+            {rocket.reserved === false && (
+              <button
+                onClick={() => reserveRocketsProps(rocket.id)}
+                className="rocket_reserve"
+                type="button"
+              >
+                Reserve Rocket
+              </button>
+            )} */}
         </li>
       ))}
     </ul>

--- a/src/pages/rockets.js
+++ b/src/pages/rockets.js
@@ -5,9 +5,6 @@ import PropTypes from 'prop-types';
 const Rockets = (props) => {
   const { rockets, reserveRocketsProps } = props;
   return (
-    // <div>
-    //   <p>Development in progress</p>
-    // </div>
     <ul className="rockets_ul">
       {rockets.map((rocket) => (
         <li className="rocket_item" key={rocket.id}>
@@ -36,32 +33,6 @@ const Rockets = (props) => {
               {rocket.reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
             </button>
           </div>
-          {/* {!rocket.reserved && (
-              <button
-                onClick={() => reserveRocketsProps(rocket.id)}
-                className="rocket_reserve"
-                type="button"
-              >
-                Reserve Rocket
-              </button>
-            )}
-            {rocket.reserved === true && (
-              <button
-                type="button"
-                onClick={() => reserveRocketsProps(rocket.id)}
-              >
-                Cancel Reservation
-              </button>
-            )}
-            {rocket.reserved === false && (
-              <button
-                onClick={() => reserveRocketsProps(rocket.id)}
-                className="rocket_reserve"
-                type="button"
-              >
-                Reserve Rocket
-              </button>
-            )} */}
         </li>
       ))}
     </ul>


### PR DESCRIPTION
- Rockets that have already been reserved show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)
- Use the React conditional rendering syntax